### PR TITLE
Add npm/browserify support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Leaflet.EditInOSM.js
+++ b/Leaflet.EditInOSM.js
@@ -1,5 +1,21 @@
-(function (L, setTimeout) {
-
+(function (factory) {
+    var L;
+    if (typeof define === 'function' && define.amd) {
+        // AMD
+        define(['leaflet'], function(L) {
+            factory(L, setTimeout);
+        });
+    } else if (typeof module !== 'undefined') {
+        // Node/CommonJS
+        L = require('leaflet');
+        module.exports = factory(L, setTimeout);
+    } else {
+        // Browser globals
+        if (typeof window.L === 'undefined')
+            throw 'Leaflet must be loaded first';
+        factory(window.L, setTimeout);
+    }
+}(function (L, setTimeout) {
     var _controlContainer,
         _map,
         _zoomThreshold,
@@ -206,4 +222,4 @@
         }
     });
 
-})(L, setTimeout);
+}));

--- a/examples/browserify.html
+++ b/examples/browserify.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="../Leaflet.EditInOSM.css" />
+</head>
+<body>
+    <div id="map" style="width: 600px; height: 400px"></div>
+    <script src="js/_browserify.js"></script>
+    <script>
+        if (!window.L) {
+            alert('Please run\n\n' +
+                'npm install && browserify examples/js/browserify.js >examples/js/_browserify.js\n\n' +
+                'before loading this example.');
+        }
+    </script>
+</body>
+</html>

--- a/examples/js/browserify.js
+++ b/examples/js/browserify.js
@@ -1,0 +1,8 @@
+var L = require('leaflet'),
+    editInOSM = require('../../'),
+    map = L.map('map', {editInOSMControlOptions: {}});
+map.setView([48.4, -4.4], 13);
+
+L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "Leaflet.EditInOSM",
+  "version": "0.1.0",
+  "description": "Add a control in a Leaflet map with links to main OSM editors",
+  "main": "Leaflet.EditInOSM.js",
+  "directories": {
+    "example": "examples",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/yohanboniface/Leaflet.EditInOSM.git"
+  },
+  "keywords": [
+    "leaflet",
+    "osm"
+  ],
+  "author": "Yohan Boniface <yb@enix.org>",
+  "license": "WTFPL",
+  "bugs": {
+    "url": "https://github.com/yohanboniface/Leaflet.EditInOSM/issues"
+  },
+  "homepage": "https://github.com/yohanboniface/Leaflet.EditInOSM",
+  "dependencies": {
+    "leaflet": "^0.7.3"
+  }
+}


### PR DESCRIPTION
This PR makes the plugin compatible with npm/browserify, and also theoretically with AMD/RequireJS. 

Without this change, it becomes a bit tedious to use the plugin in projects where the rest of the build/dependencies are managed by npm.

I've added a `package.json` with version number 0.1.0 - feel free to change it if you feel another number better represents the state of the plugin.
